### PR TITLE
Switch get_face_single() to order from largest to smaller

### DIFF
--- a/scripts/swapper.py
+++ b/scripts/swapper.py
@@ -82,7 +82,8 @@ def get_face_single(img_data: np.ndarray, face_index=0, det_size=(640, 640)):
         return get_face_single(img_data, face_index=face_index, det_size=det_size_half)
 
     try:
-        return sorted(face, key=lambda x: x.bbox[0])[face_index]
+        # Put the largest first (x2 - x1) * (y2 - y1)
+        return sorted(face, reverse=True, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]))[face_index]
     except IndexError:
         return None
 


### PR DESCRIPTION
Similar to my PR at roop https://github.com/s0md3v/roop/pull/731

Many times I wished the order was closer to what I expected. I tried to find concrete docs on the faces' `bbox` but couldn't. I did find [this example](https://github.com/deepinsight/insightface/blob/master/examples/person_detection/scrfd_person.py#L36C24-L36C25) which seems good enough

The current implementation is picking whichever is more to the left. I think a better default (given one HAS to be chosen) is grabbing the largest one. That's usually the one closer to the viewer and the main point of focus.