### PR TITLE
remove launch package from install script dependencies

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,6 +1,5 @@
-import launch
 import os
-import pkg_resources
+import subprocess  
 import sys
 from tqdm import tqdm
 import urllib.request
@@ -24,31 +23,8 @@ if not os.path.exists(models_dir):
 if not os.path.exists(model_path):
     download(model_url, model_path)
 
-print("Checking roop requirements")
-with open(req_file) as file:
-    for package in file:
-        try:
-            python = sys.executable
-            package = package.strip()
-
-            if not launch.is_installed(package):
-                print(f"Install {package}")
-                launch.run_pip(
-                    f"install {package}", f"sd-webui-roop requirement: {package}"
-                )
-            elif "==" in package:
-                package_name, package_version = package.split("==")
-                installed_version = pkg_resources.get_distribution(package_name).version
-                if installed_version != package_version:
-                    print(
-                        f"Install {package}, {installed_version} vs {package_version}"
-                    )
-                    launch.run_pip(
-                        f"install {package}",
-                        f"sd-webui-roop requirement: changing {package_name} version from {installed_version} to {package_version}",
-                    )
-
-        except Exception as e:
-            print(e)
-            print(f"Warning: Failed to install {package}, roop will not work.")
-            raise e
+try:
+    subprocess.run(["pip", "install", "-r", req_file], check=True)
+except subprocess.CalledProcessError as e:
+    print(f"Failed to install requirements: {e.stderr.decode('utf-8')}")
+    sys.exit(1)


### PR DESCRIPTION
I want to merge this pull request because it uses the native `subprocess` to install dependencies instead of the `launch` package, see issue https://github.com/s0md3v/sd-webui-roop/issues/260